### PR TITLE
Drop noop ocr flags

### DIFF
--- a/modules/paperless.nix
+++ b/modules/paperless.nix
@@ -16,10 +16,6 @@
     settings = {
       PAPERLESS_OCR_OUTPUT_TYPE = "pdf"; # 2025-02-28 Adding this in to preserve hyperlinks in PDFs generated
       PAPERLESS_OCR_LANGUAGE = "eng";
-      PAPERLESS_OCR_USER_ARGS = {
-        optimize = 1;
-        pdfa_image_compression = "lossless";
-      };
       PAPERLESS_TIKA_ENABLED = true;
       PAPERLESS_GOTENBERG_ENABLED = true;
     };


### PR DESCRIPTION
optimize 1 is the default and without pdfa there is no image compression https://github.com/ocrmypdf/OCRmyPDF/blob/8b1443c4826e8ebe4556c8b0d1cdfc31bc83c3c8/src/ocrmypdf/builtin_plugins/ghostscript.py#L87-L88