### PR TITLE
Drop redundant packages

### DIFF
--- a/modules/tailscale-performance-miniserver.nix
+++ b/modules/tailscale-performance-miniserver.nix
@@ -6,11 +6,6 @@
 }:
 
 {
-  environment.systemPackages = with pkgs; [
-    ethtool
-    networkd-dispatcher
-  ];
-
   services = {
     networkd-dispatcher = {
       enable = true;


### PR DESCRIPTION
ethtool ist used through an absolute path and networkd-dispatcher is already added through https://github.com/NixOS/nixpkgs/blob/7819a0d29d1dd2bc331bec4b327f0776359b1fa6/nixos/modules/services/networking/networkd-dispatcher.nix#L87